### PR TITLE
Trade history coinnect bitstamp

### DIFF
--- a/src/bitstamp/api.rs
+++ b/src/bitstamp/api.rs
@@ -183,12 +183,12 @@ impl ExchangeApi for BitstampApi {
     /// ```
     fn return_ticker(&mut self, pair: Pair) -> Option<Map<String, Value>> {
 
-        let wanted_pair = match pair {
+        let currency_pair = match pair {
             Pair::BtcUsd => "btcusd",
         };
 
         let mut params = HashMap::new();
-        params.insert("pair", wanted_pair);
+        params.insert("pair", currency_pair);
         params.insert("method", "ticker");
         self.public_query(&params)
     }
@@ -201,15 +201,36 @@ impl ExchangeApi for BitstampApi {
     /// ```
     fn return_order_book(&mut self, pair: Pair) -> Option<Map<String, Value>> {
 
-        let wanted_pair = match pair {
+        let currency_pair = match pair {
+        Pair::BtcUsd => "btcusd",
+    };
+
+        let mut params = HashMap::new();
+        params.insert("method", "order_book");
+        params.insert("pair", currency_pair);
+        self.public_query(&params)
+    }
+
+    /// Sample output :
+    ///
+    /// ```ignore
+    /// [{"date":"2014-02-10 04:23:23","type":"buy","rate":"0.00007600","amount":"140",
+    /// "total":"0.01064"},
+    /// {"date":"2014-02-10 01:19:37","type":"buy","rate":"0.00007600","amount":"655",
+    /// "total":"0.04978"}, ... ]
+    /// ```
+    fn return_trade_history(&mut self, pair: Pair) -> Option<Map<String, Value>> {
+
+        let currency_pair = match pair {
             Pair::BtcUsd => "btcusd",
         };
 
         let mut params = HashMap::new();
-        params.insert("method", "order_book");
-        params.insert("pair", wanted_pair);
+        params.insert("pair", currency_pair);
+        params.insert("method", "transactions");
         self.public_query(&params)
     }
+
 
     /// Returns all of your available balances.
     ///
@@ -220,13 +241,13 @@ impl ExchangeApi for BitstampApi {
     /// ```
     fn return_balances(&mut self, pair: Pair) -> Option<Map<String, Value>> {
 
-        let wanted_pair = match pair {
+        let currency_pair = match pair {
             Pair::BtcUsd => "btcusd",
         };
 
         let mut params = HashMap::new();
         params.insert("method", "balance");
-        params.insert("pair", wanted_pair);
+        params.insert("pair", currency_pair);
         self.private_query(&params)
     }
 }

--- a/src/bitstamp/api.rs
+++ b/src/bitstamp/api.rs
@@ -184,7 +184,8 @@ impl ExchangeApi for BitstampApi {
     fn return_ticker(&mut self, pair: Pair) -> Option<Map<String, Value>> {
 
         let currency_pair = match pair {
-            Pair::BtcUsd => "btcusd",
+            Pair::BTC_USD => "btcusd",
+            _  => panic!("Unknown pair"),
         };
 
         let mut params = HashMap::new();
@@ -202,8 +203,9 @@ impl ExchangeApi for BitstampApi {
     fn return_order_book(&mut self, pair: Pair) -> Option<Map<String, Value>> {
 
         let currency_pair = match pair {
-        Pair::BtcUsd => "btcusd",
-    };
+            Pair::BTC_USD => "btcusd",
+            _  => panic!("Unknown pair"),
+        };
 
         let mut params = HashMap::new();
         params.insert("method", "order_book");
@@ -222,7 +224,8 @@ impl ExchangeApi for BitstampApi {
     fn return_trade_history(&mut self, pair: Pair) -> Option<Map<String, Value>> {
 
         let currency_pair = match pair {
-            Pair::BtcUsd => "btcusd",
+            Pair::BTC_USD => "btcusd",
+            _  => panic!("Unknown pair"),
         };
 
         let mut params = HashMap::new();
@@ -242,7 +245,8 @@ impl ExchangeApi for BitstampApi {
     fn return_balances(&mut self, pair: Pair) -> Option<Map<String, Value>> {
 
         let currency_pair = match pair {
-            Pair::BtcUsd => "btcusd",
+            Pair::BTC_USD => "btcusd",
+            _  => panic!("Unknown pair"),
         };
 
         let mut params = HashMap::new();

--- a/src/coinnect.rs
+++ b/src/coinnect.rs
@@ -56,6 +56,9 @@ impl ExchangeApi for UnimplementedApi {
     fn return_ticker(&mut self, _: Pair) -> Option<Map<String, Value>> {
         panic!("Not implemented");
     }
+    fn return_trade_history(&mut self, _: Pair) -> Option<Map<String, Value>> {
+        panic!("Not implemented");
+    }
     fn return_order_book(&mut self, _: Pair) -> Option<Map<String, Value>> {
         panic!("Not implemented");
     }

--- a/src/coinnect.rs
+++ b/src/coinnect.rs
@@ -47,22 +47,22 @@ struct UnimplementedApi;
 
 impl ExchangeApi for UnimplementedApi {
     fn public_query(&mut self, _: &HashMap<&str, &str>) -> Option<Map<String, Value>> {
-        panic!("Not implemented");
+        unimplemented!();
     }
     fn private_query(&mut self, _: &HashMap<&str, &str>) -> Option<Map<String, Value>> {
-        panic!("Not implemented");
+        unimplemented!();
     }
 
     fn return_ticker(&mut self, _: Pair) -> Option<Map<String, Value>> {
-        panic!("Not implemented");
+        unimplemented!();
     }
     fn return_trade_history(&mut self, _: Pair) -> Option<Map<String, Value>> {
-        panic!("Not implemented");
+        unimplemented!();
     }
     fn return_order_book(&mut self, _: Pair) -> Option<Map<String, Value>> {
-        panic!("Not implemented");
+        unimplemented!();
     }
     fn return_balances(&mut self, _: Pair) -> Option<Map<String, Value>> {
-        panic!("Not implemented");
+        unimplemented!();
     }
 }

--- a/src/exchange.rs
+++ b/src/exchange.rs
@@ -20,5 +20,7 @@ pub trait ExchangeApi: Debug {
 
     fn return_ticker(&mut self, pair: Pair) -> Option<Map<String, Value>>;
     fn return_order_book(&mut self, pair: Pair) -> Option<Map<String, Value>>;
+    fn return_trade_history(&mut self, pair: Pair) -> Option<Map<String, Value>>;
+
     fn return_balances(&mut self, pair: Pair) -> Option<Map<String, Value>>;
 }

--- a/src/pair.rs
+++ b/src/pair.rs
@@ -1,5 +1,17 @@
 #[derive(Debug)]
 #[derive(PartialEq)]
+#[allow(non_camel_case_types)]
 pub enum Pair {
-    BtcUsd,
+    BTC_EUR,
+    BTC_USD,
+    ETC_BTC,
+    ETC_EUR,
+    ETC_USD,
+    ETH_BTC,
+    ETH_EUR,
+    ETH_USD,
+    EUR_USD,
+    XRP_BTC,
+    XRP_EUR,
+    XRP_USD,
 }

--- a/tests/bitstamp.rs
+++ b/tests/bitstamp.rs
@@ -26,7 +26,7 @@ mod bitstamp_tests {
     fn can_get_real_bitstamp_tick() {
         let params = HashMap::new();
         let mut api = BitstampApi::new(&params);
-        let result = api.return_ticker(Pair::BtcUsd);
+        let result = api.return_ticker(Pair::BTC_USD);
         assert_eq!(result.is_some(), true);
     }
 
@@ -34,63 +34,63 @@ mod bitstamp_tests {
     fn ticker_should_have_the_correct_last() {
         let params = HashMap::new();
         let mut api = BitstampApi::new(&params);
-        let result = api.return_ticker(Pair::BtcUsd);
+        let result = api.return_ticker(Pair::BTC_USD);
         assert!(result.unwrap().contains_key("last"));
     }
     #[test]
     fn ticker_should_have_the_correct_high() {
         let params = HashMap::new();
         let mut api = BitstampApi::new(&params);
-        let result = api.return_ticker(Pair::BtcUsd);
+        let result = api.return_ticker(Pair::BTC_USD);
         assert!(result.unwrap().contains_key("high"));
     }
     #[test]
     fn ticker_should_have_the_correct_low() {
         let params = HashMap::new();
         let mut api = BitstampApi::new(&params);
-        let result = api.return_ticker(Pair::BtcUsd);
+        let result = api.return_ticker(Pair::BTC_USD);
         assert!(result.unwrap().contains_key("low"));
     }
     #[test]
     fn ticker_should_have_the_correct_vwap() {
         let params = HashMap::new();
         let mut api = BitstampApi::new(&params);
-        let result = api.return_ticker(Pair::BtcUsd);
+        let result = api.return_ticker(Pair::BTC_USD);
         assert!(result.unwrap().contains_key("vwap"));
     }
     #[test]
     fn ticker_should_have_the_correct_volume() {
         let params = HashMap::new();
         let mut api = BitstampApi::new(&params);
-        let result = api.return_ticker(Pair::BtcUsd);
+        let result = api.return_ticker(Pair::BTC_USD);
         assert!(result.unwrap().contains_key("volume"));
     }
     #[test]
     fn ticker_should_have_the_correct_bid() {
         let params = HashMap::new();
         let mut api = BitstampApi::new(&params);
-        let result = api.return_ticker(Pair::BtcUsd);
+        let result = api.return_ticker(Pair::BTC_USD);
         assert!(result.unwrap().contains_key("bid"));
     }
     #[test]
     fn ticker_should_have_the_correct_ask() {
         let params = HashMap::new();
         let mut api = BitstampApi::new(&params);
-        let result = api.return_ticker(Pair::BtcUsd);
+        let result = api.return_ticker(Pair::BTC_USD);
         assert!(result.unwrap().contains_key("ask"));
     }
     #[test]
     fn ticker_should_have_the_correct_timestamp() {
         let params = HashMap::new();
         let mut api = BitstampApi::new(&params);
-        let result = api.return_ticker(Pair::BtcUsd);
+        let result = api.return_ticker(Pair::BTC_USD);
         assert!(result.unwrap().contains_key("timestamp"));
     }
     #[test]
     fn ticker_should_have_the_correct_open() {
         let params = HashMap::new();
         let mut api = BitstampApi::new(&params);
-        let result = api.return_ticker(Pair::BtcUsd);
+        let result = api.return_ticker(Pair::BTC_USD);
         assert!(result.unwrap().contains_key("open"));
     }
 
@@ -98,7 +98,7 @@ mod bitstamp_tests {
     fn should_return_an_order_book() {
         let params = HashMap::new();
         let mut api = BitstampApi::new(&params);
-        let result = api.return_order_book(Pair::BtcUsd);
+        let result = api.return_order_book(Pair::BTC_USD);
         assert_eq!(result.is_some(), true);
     }
 
@@ -106,21 +106,21 @@ mod bitstamp_tests {
     fn order_book_should_have_a_timestamp() {
         let params = HashMap::new();
         let mut api = BitstampApi::new(&params);
-        let result = api.return_order_book(Pair::BtcUsd);
+        let result = api.return_order_book(Pair::BTC_USD);
         assert!(result.unwrap().contains_key("timestamp"));
     }
     #[test]
     fn order_book_should_have_bids() {
         let params = HashMap::new();
         let mut api = BitstampApi::new(&params);
-        let result = api.return_order_book(Pair::BtcUsd);
+        let result = api.return_order_book(Pair::BTC_USD);
         assert!(result.unwrap().contains_key("bids"));
     }
     #[test]
     fn order_book_should_have_asks() {
         let params = HashMap::new();
         let mut api = BitstampApi::new(&params);
-        let result = api.return_order_book(Pair::BtcUsd);
+        let result = api.return_order_book(Pair::BTC_USD);
         assert!(result.unwrap().contains_key("bids"));
     }
 
@@ -128,13 +128,13 @@ mod bitstamp_tests {
     fn order_book_should_have_asks_for_btcusd() {
         let params = HashMap::new();
         let mut api = BitstampApi::new(&params);
-        assert!(api.return_order_book(Pair::BtcUsd).unwrap().contains_key("asks"));
+        assert!(api.return_order_book(Pair::BTC_USD).unwrap().contains_key("asks"));
     }
     #[test]
     fn order_book_should_have_asks_for_btceur() {
         let params = HashMap::new();
         let mut api = BitstampApi::new(&params);
-        assert!(api.return_order_book(Pair::BtcUsd).unwrap().contains_key("asks"));
+        assert!(api.return_order_book(Pair::BTC_USD).unwrap().contains_key("asks"));
     }
 
     #[test]
@@ -174,7 +174,7 @@ mod bitstamp_tests {
     fn should_return_the_trade_history_for_btc_usd() {
         let params = HashMap::new();
         let mut api = BitstampApi::new(&params);
-        let result = api.return_trade_history(Pair::BtcUsd);
+        let result = api.return_trade_history(Pair::BTC_USD);
 
         assert_eq!( result.is_some(), false );
     }
@@ -185,7 +185,7 @@ mod bitstamp_tests {
         use std::path::PathBuf;
         let path = PathBuf::from("./keys_real.json");
         let mut api = BitstampApi::new_from_file("account_bitstamp", path);
-        let result = api.return_balances(Pair::BtcUsd).unwrap();
+        let result = api.return_balances(Pair::BTC_USD).unwrap();
         let result_looking_for_usd = result.clone();
         let result_looking_for_btc = result.clone();
         let result_looking_for_fee = result.clone();

--- a/tests/bitstamp.rs
+++ b/tests/bitstamp.rs
@@ -15,6 +15,12 @@ mod bitstamp_tests {
             utils::build_url("ticker", "btcusd"),
             "https://www.bitstamp.net/api/v2/ticker/btcusd/");
     }
+    #[test]
+    fn build_url_should_return_the_url_for_transactions_for_btc_usd() {
+        assert_eq!(
+            utils::build_url("transactions", "btcusd"),
+            "https://www.bitstamp.net/api/v2/transactions/btcusd/");
+    }
 
     #[test]
     fn can_get_real_bitstamp_tick() {
@@ -150,6 +156,27 @@ mod bitstamp_tests {
             utils::build_signature(nonce, customer_id, api_key, api_secret),
             expected_signature
         );
+    }
+
+    #[test]
+    fn should_return_the_trade_history_for_btc_usd_from_public_query() {
+        let mut params = HashMap::new();
+        let mut api = BitstampApi::new(&params);
+
+        params.insert("pair", "btcusd");
+        params.insert("method", "transactions");
+        let result = api.public_query(&params);
+
+        assert_eq!( result.is_some(), false );
+    }
+
+    #[test]
+    fn should_return_the_trade_history_for_btc_usd() {
+        let params = HashMap::new();
+        let mut api = BitstampApi::new(&params);
+        let result = api.return_trade_history(Pair::BtcUsd);
+
+        assert_eq!( result.is_some(), false );
     }
 
     // IMPORTANT: Real keys are needed in order to retrieve the balance

--- a/tests/coinnect.rs
+++ b/tests/coinnect.rs
@@ -37,14 +37,14 @@ mod coinnect_tests {
     #[test]
     fn coinnect_can_get_a_ticker_from_bitstamp() {
         let mut api = Coinnect::new(Exchange::Bitstamp, "bs_cust_id", "bs_api_key", "bs_api_secret");
-        let ticker = api.return_ticker(Pair::BtcUsd);
+        let ticker = api.return_ticker(Pair::BTC_USD);
 
         assert!( ticker.is_some() );
     }
     #[test]
     fn coinnect_ticker_from_bitstamp_should_have_the_correct_last() {
         let mut api = Coinnect::new(Exchange::Bitstamp, "bs_cust_id", "bs_api_key", "bs_api_secret");
-        let ticker = api.return_ticker(Pair::BtcUsd);
+        let ticker = api.return_ticker(Pair::BTC_USD);
 
         assert!( ticker.unwrap().contains_key("last") );
     }
@@ -52,13 +52,13 @@ mod coinnect_tests {
     #[test]
     fn coinnect_should_return_an_order_book_from_bitstamp() {
         let mut api = Coinnect::new(Exchange::Bitstamp, "bs_cust_id", "bs_api_key", "bs_api_secret");
-        let order_book = api.return_order_book(Pair::BtcUsd);
+        let order_book = api.return_order_book(Pair::BTC_USD);
         assert!( order_book.is_some() );
     }
     #[test]
     fn order_book_should_have_bids() {
         let mut api = Coinnect::new(Exchange::Bitstamp, "bs_cust_id", "bs_api_key", "bs_api_secret");
-        let result = api.return_order_book(Pair::BtcUsd);
+        let result = api.return_order_book(Pair::BTC_USD);
         assert!( result.unwrap().contains_key("bids") );
     }
 
@@ -79,7 +79,7 @@ mod coinnect_tests {
     #[test]
     fn should_return_the_trade_history_for_btc_usd_from_bitstamp() {
         let mut api = Coinnect::new(Exchange::Bitstamp, "bs_cust_id", "bs_api_key", "bs_api_secret");
-        let result = api.return_trade_history(Pair::BtcUsd);
+        let result = api.return_trade_history(Pair::BTC_USD);
 
         assert_eq!( result.is_some(), false );
     }
@@ -90,7 +90,7 @@ mod coinnect_tests {
         use std::path::PathBuf;
         let path = PathBuf::from("./keys_real.json");
         let mut api = Coinnect::new_from_file(Exchange::Bitstamp , path);
-        let result = api.return_balances(Pair::BtcUsd).unwrap();
+        let result = api.return_balances(Pair::BTC_USD).unwrap();
         let result_looking_for_usd = result.clone();
         let result_looking_for_btc = result.clone();
         let result_looking_for_fee = result.clone();

--- a/tests/coinnect.rs
+++ b/tests/coinnect.rs
@@ -62,6 +62,28 @@ mod coinnect_tests {
         assert!( result.unwrap().contains_key("bids") );
     }
 
+    #[test]
+    fn public_query_should_be_able_to_return_the_trade_history_for_btc_usd_from_bitstamp() {
+        use std::collections::HashMap;
+
+        let mut api = Coinnect::new(Exchange::Bitstamp, "bs_cust_id", "bs_api_key", "bs_api_secret");
+
+        let mut params = HashMap::new();
+        params.insert("pair", "btcusd");
+        params.insert("method", "transactions");
+        let result = api.public_query(&params);
+
+        assert_eq!( result.is_some(), false );
+    }
+
+    #[test]
+    fn should_return_the_trade_history_for_btc_usd_from_bitstamp() {
+        let mut api = Coinnect::new(Exchange::Bitstamp, "bs_cust_id", "bs_api_key", "bs_api_secret");
+        let result = api.return_trade_history(Pair::BtcUsd);
+
+        assert_eq!( result.is_some(), false );
+    }
+
     // IMPORTANT: Real keys are needed in order to retrieve the balance
     #[test]
     fn balance_should_have_usd_btc_fee() {


### PR DESCRIPTION
Implement the trade history. The default output, not specifying start or end.