### PR TITLE
Configure travis.ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,1 @@
+language: rust


### PR DESCRIPTION
To be sure about the health of the library it's convenient to have a CI running the tests externally to the local development machines. In order to do that I configured Travis.ci for my clone of the repository.

Since only the admins of a repository can configure travis for a repository, @hugues31 , you should configure travis yourself. The configuration is the same of this pull request, since it doesn't specify credentials. I can help you further with this if you need help.

For this pull request you get: <img src="https://travis-ci.org/ainestal/coinnect.svg?branch=master" alt="build:passed">