### PR TITLE
WIP Add a generic credential system

### DIFF
--- a/examples/generic_api.rs
+++ b/examples/generic_api.rs
@@ -7,13 +7,15 @@
 extern crate coinnect;
 
 use coinnect::coinnect::Coinnect;
+use coinnect::kraken::KrakenCreds;
 use coinnect::exchange::Exchange::*;
 use coinnect::pair::Pair::*;
 
 fn main() {
     // We create a Coinnect Generic API
     // Since Kraken does not need customer_id field, we set it to None
-    let mut my_api = Coinnect::new(Kraken, "api_key", "api_secret", None).unwrap();
+    let my_creds = KrakenCreds::new("my_optionnal_name", "api_key", "api_secret");
+    let mut my_api = Coinnect::new(Kraken, my_creds).unwrap();
     let ticker = my_api.ticker(ETC_BTC);
 
     println!("ETC_BTC last trade price is {}.",

--- a/examples/kraken_trading.rs
+++ b/examples/kraken_trading.rs
@@ -8,14 +8,17 @@ extern crate coinnect;
 
 use std::path::PathBuf;
 
-use coinnect::kraken::api::KrakenApi;
+use coinnect::kraken::{KrakenApi, KrakenCreds};
 use std::error::Error;
 
 fn main() {
     // We create a KrakenApi by loading a json file containing API configuration
     // (see documentation for more info)
     let path = PathBuf::from("keys_real.json");
-    let mut my_api = KrakenApi::new_from_file("account_kraken", path).unwrap();
+    let my_creds = KrakenCreds::new_from_file("account_kraken", path).unwrap();
+    let mut my_api = KrakenApi::new(my_creds).unwrap();
+
+
 
     // First, get the list of all pair we can trade with EUR€ as quote
     // You could use a simple unwrap() or use match to recover from an error for example

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -2,12 +2,13 @@
 
 extern crate coinnect;
 
-use coinnect::poloniex::api::PoloniexApi;
+use coinnect::poloniex::{PoloniexApi, PoloniexCreds};
 
 fn main() {
     // We create a PoloniexApi by providing API key/secret
     // You can give an empty String if you only use public methods
-    let mut my_api = PoloniexApi::new("api_key", "api_secret").unwrap();
+    let creds = PoloniexCreds::new("my_optionnal_name", "api_key", "api_secret");
+    let mut my_api = PoloniexApi::new(creds).unwrap();
 
     // Let's look at the ticker!
     let list_coins = my_api.return_ticker().unwrap();

--- a/src/bitstamp/credentials.rs
+++ b/src/bitstamp/credentials.rs
@@ -36,21 +36,21 @@ impl BitstampCreds {
 
 
         //if api_key.is_empty() {
-        //warning!("No API key set for the Bistamp client");
+        //warning!("No API key set for the Bitstamp client");
         //}
         creds
             .data
             .insert("api_key".to_string(), api_key.to_string());
 
         //if api_secret.is_empty() {
-        //warning!("No API secret set for the Bistamp client");
+        //warning!("No API secret set for the Bitstamp client");
         //}
         creds
             .data
             .insert("api_secret".to_string(), api_secret.to_string());
 
         //if api_secret.is_empty() {
-        //warning!("No API customer ID set for the Bistamp client");
+        //warning!("No API customer ID set for the Bitstamp client");
         //}
         creds
             .data
@@ -79,7 +79,7 @@ impl BitstampCreds {
     /// }
     /// ```
     /// For this example, you could use load your Bitstamp account with
-    /// `BistampAPI::new(BitstampCreds::new_from_file("account_bitstamp", Path::new("/keys.json")))`
+    /// `BitstampAPI::new(BitstampCreds::new_from_file("account_bitstamp", Path::new("/keys.json")))`
     pub fn new_from_file(name: &str, path: PathBuf) -> Result<Self> {
         let mut f = File::open(&path)?;
         let mut buffer = String::new();

--- a/src/bitstamp/credentials.rs
+++ b/src/bitstamp/credentials.rs
@@ -1,18 +1,18 @@
 //! Contains the Bitstamp credentials.
 
-use std::collections::HashMap;
-use std::str::FromStr;
-
 use serde_json;
 use serde_json::Value;
 
 use coinnect::Credentials;
 use exchange::Exchange;
+use helpers;
+use error::*;
 
+use std::collections::HashMap;
+use std::str::FromStr;
 use std::fs::File;
 use std::io::Read;
 use std::path::PathBuf;
-use error::*;
 
 #[derive(Debug)]
 pub struct BitstampCreds {
@@ -90,31 +90,11 @@ impl BitstampCreds {
             .ok_or_else(|| ErrorKind::BadParse)?
             .get(name)
             .ok_or_else(|| ErrorKind::MissingField(name.to_string()))?;
-        let api_key = json_obj
-            .get("api_key")
-            .ok_or_else(|| ErrorKind::MissingField("api_key".to_string()))?
-            .as_str()
-            .ok_or_else(|| ErrorKind::InvalidFieldFormat("api_key".to_string()))?;
-        let api_secret =
-            json_obj
-                .get("api_secret")
-                .ok_or_else(|| ErrorKind::MissingField("api_secret".to_string()))?
-                .as_str()
-                .ok_or_else(|| ErrorKind::InvalidFieldFormat("api_secret".to_string()))?;
-        let customer_id =
-            json_obj
-                .get("customer_id")
-                .ok_or_else(|| ErrorKind::MissingField("customer_id".to_string()))?
-                .as_str()
-                .ok_or_else(|| ErrorKind::InvalidFieldFormat("customer_id".to_string()))?;
+        let api_key = helpers::get_json_string(json_obj, "api_key")?;
+        let api_secret = helpers::get_json_string(json_obj, "api_secret")?;
+        let customer_id = helpers::get_json_string(json_obj, "customer_id")?;
         let exchange = {
-            let exchange_str =
-                json_obj
-                    .get("exchange")
-                    .ok_or_else(|| ErrorKind::MissingField("customer_id".to_string()))?
-                    .as_str()
-                    .ok_or_else(|| ErrorKind::InvalidFieldFormat("customer_id".to_string()))?;
-
+            let exchange_str = helpers::get_json_string(json_obj, "exchange")?;
             Exchange::from_str(exchange_str)
                 .chain_err(|| ErrorKind::InvalidFieldValue("exchange".to_string()))?
         };

--- a/src/bitstamp/credentials.rs
+++ b/src/bitstamp/credentials.rs
@@ -90,6 +90,7 @@ impl BitstampCreds {
             .ok_or_else(|| ErrorKind::BadParse)?
             .get(name)
             .ok_or_else(|| ErrorKind::MissingField(name.to_string()))?;
+
         let api_key = helpers::get_json_string(json_obj, "api_key")?;
         let api_secret = helpers::get_json_string(json_obj, "api_secret")?;
         let customer_id = helpers::get_json_string(json_obj, "customer_id")?;

--- a/src/bitstamp/credentials.rs
+++ b/src/bitstamp/credentials.rs
@@ -1,0 +1,147 @@
+//! Contains the Bitstamp credentials.
+
+use std::collections::HashMap;
+use std::str::FromStr;
+
+use serde_json;
+use serde_json::Value;
+
+use coinnect::Credentials;
+use exchange::Exchange;
+
+use std::fs::File;
+use std::io::Read;
+use std::path::PathBuf;
+use error::*;
+
+#[derive(Debug)]
+pub struct BitstampCreds {
+    exchange: Exchange,
+    name: String,
+    data: HashMap<String, String>,
+}
+
+impl BitstampCreds {
+    /// Create a new `BitstampCreds` from arguments.
+    pub fn new(name: &str, api_key: &str, api_secret: &str, customer_id: &str) -> Self {
+        let mut creds = BitstampCreds {
+            data: HashMap::new(),
+            exchange: Exchange::Bitstamp,
+            name: if name.is_empty() {
+                "BitstampClient".to_string()
+            } else {
+                name.to_string()
+            },
+        };
+
+
+        //if api_key.is_empty() {
+        //warning!("No API key set for the Bistamp client");
+        //}
+        creds
+            .data
+            .insert("api_key".to_string(), api_key.to_string());
+
+        //if api_secret.is_empty() {
+        //warning!("No API secret set for the Bistamp client");
+        //}
+        creds
+            .data
+            .insert("api_secret".to_string(), api_secret.to_string());
+
+        //if api_secret.is_empty() {
+        //warning!("No API customer ID set for the Bistamp client");
+        //}
+        creds
+            .data
+            .insert("customer_id".to_string(), customer_id.to_string());
+
+        creds
+    }
+
+
+    /// Create a new `BitstampCreds` from a json configuration file. This file must follow this
+    /// structure:
+    ///
+    /// ```json
+    /// {
+    ///     "account_kraken": {
+    ///         "exchange"  : "kraken",
+    ///         "api_key"   : "123456789ABCDEF",
+    ///         "api_secret": "ABC&EF?abcdef"
+    ///     },
+    ///     "account_bitstamp": {
+    ///         "exchange"   : "bitstamp",
+    ///         "api_key"    : "1234567890ABCDEF1234567890ABCDEF",
+    ///         "api_secret" : "1234567890ABCDEF1234567890ABCDEF",
+    ///         "customer_id": "123456"
+    ///     }
+    /// }
+    /// ```
+    /// For this example, you could use load your Bitstamp account with
+    /// `BistampAPI::new(BitstampCreds::new_from_file("account_bitstamp", Path::new("/keys.json")))`
+    pub fn new_from_file(name: &str, path: PathBuf) -> Result<Self> {
+        let mut f = File::open(&path)?;
+        let mut buffer = String::new();
+        f.read_to_string(&mut buffer)?;
+
+        let data: Value = serde_json::from_str(&buffer)?;
+        let json_obj = data.as_object()
+            .ok_or_else(|| ErrorKind::BadParse)?
+            .get(name)
+            .ok_or_else(|| ErrorKind::MissingField(name.to_string()))?;
+        let api_key = json_obj
+            .get("api_key")
+            .ok_or_else(|| ErrorKind::MissingField("api_key".to_string()))?
+            .as_str()
+            .ok_or_else(|| ErrorKind::InvalidFieldFormat("api_key".to_string()))?;
+        let api_secret =
+            json_obj
+                .get("api_secret")
+                .ok_or_else(|| ErrorKind::MissingField("api_secret".to_string()))?
+                .as_str()
+                .ok_or_else(|| ErrorKind::InvalidFieldFormat("api_secret".to_string()))?;
+        let customer_id =
+            json_obj
+                .get("customer_id")
+                .ok_or_else(|| ErrorKind::MissingField("customer_id".to_string()))?
+                .as_str()
+                .ok_or_else(|| ErrorKind::InvalidFieldFormat("customer_id".to_string()))?;
+        let exchange = {
+            let exchange_str =
+                json_obj
+                    .get("exchange")
+                    .ok_or_else(|| ErrorKind::MissingField("customer_id".to_string()))?
+                    .as_str()
+                    .ok_or_else(|| ErrorKind::InvalidFieldFormat("customer_id".to_string()))?;
+
+            Exchange::from_str(exchange_str)
+                .chain_err(|| ErrorKind::InvalidFieldValue("exchange".to_string()))?
+        };
+
+        if exchange != Exchange::Bitstamp {
+            return Err(ErrorKind::InvalidConfigType(Exchange::Bitstamp, exchange).into());
+        }
+
+        Ok(BitstampCreds::new(name, api_key, api_secret, customer_id))
+    }
+}
+
+impl Credentials for BitstampCreds {
+    /// Return a value from the credentials.
+    fn get(&self, key: &str) -> Option<String> {
+        if let Some(res) = self.data.get(key) {
+            Some(res.clone())
+        } else {
+            None
+        }
+    }
+
+    fn name(&self) -> String {
+        self.name.clone()
+    }
+
+    fn exchange(&self) -> Exchange {
+        self.exchange
+    }
+}

--- a/src/bitstamp/generic_api.rs
+++ b/src/bitstamp/generic_api.rs
@@ -16,29 +16,10 @@ impl ExchangeApi for BitstampApi {
 
         let result = self.return_ticker(pair)?;
 
-        //let parse_as_float = |field: &str| field.parse::<f64>()?;
-
-        let price = result["last"]
-            .as_str()
-            .ok_or_else(|| ErrorKind::MissingField("last".to_string()))?
-            .parse::<f64>()
-            .chain_err(|| ErrorKind::InvalidFieldFormat("last".to_string()))?;
-
-        let ask = result["ask"]
-            .as_str()
-            .ok_or_else(|| ErrorKind::MissingField("ask".to_string()))?
-            .parse::<f64>()
-            .chain_err(|| ErrorKind::InvalidFieldFormat("ask".to_string()))?;
-        let bid = result["bid"]
-            .as_str()
-            .ok_or_else(|| ErrorKind::MissingField("bid".to_string()))?
-            .parse::<f64>()
-            .chain_err(|| ErrorKind::InvalidFieldFormat("bid".to_string()))?;
-        let vol = result["volume"]
-            .as_str()
-            .ok_or_else(|| ErrorKind::MissingField("volume".to_string()))?
-            .parse::<f64>()
-            .chain_err(|| ErrorKind::InvalidFieldFormat("volume".to_string()))?;
+        let price = helpers::from_json_float(&result["last"], "last")?;
+        let ask = helpers::from_json_float(&result["ask"], "ask")?;
+        let bid = helpers::from_json_float(&result["bid"], "bid")?;
+        let vol = helpers::from_json_float(&result["volume"], "volume")?;
 
         Ok(Ticker {
                timestamp: helpers::get_unix_timestamp_ms(),

--- a/src/bitstamp/mod.rs
+++ b/src/bitstamp/mod.rs
@@ -2,4 +2,8 @@
 
 pub mod api;
 pub mod generic_api;
+pub mod credentials;
 pub mod utils;
+
+pub use self::credentials::BitstampCreds;
+pub use self::api::BitstampApi;

--- a/src/coinnect.rs
+++ b/src/coinnect.rs
@@ -3,39 +3,33 @@
 
 #![allow(new_ret_no_self)]
 
-use std::collections::HashMap;
 use std::path::PathBuf;
 
 use exchange::{Exchange, ExchangeApi};
-use bitstamp::api::BitstampApi;
-use kraken::api::KrakenApi;
-use poloniex::api::PoloniexApi;
+use bitstamp::{BitstampApi, BitstampCreds};
+use kraken::{KrakenApi, KrakenCreds};
+use poloniex::{PoloniexApi, PoloniexCreds};
 use error::*;
+
+pub trait Credentials {
+    /// Get an element from the credentials.
+    fn get(&self, cred: &str) -> Option<String>;
+    /// Return the targeted `Exchange`.
+    fn exchange(&self) -> Exchange;
+    /// Return the client name.
+    fn name(&self) -> String;
+}
 
 #[derive(Debug)]
 pub struct Coinnect;
 
 impl Coinnect {
     /// Create a new CoinnectApi by providing an API key & API secret
-    pub fn new(exchange: Exchange,
-               api_key: &str,
-               api_secret: &str,
-               customer_id: Option<&str>)
-               -> Result<Box<ExchangeApi>> {
+    pub fn new<C: Credentials>(exchange: Exchange, creds: C) -> Result<Box<ExchangeApi>> {
         match exchange {
-            Exchange::Bitstamp => {
-                let mut params = HashMap::new();
-                params.insert("api_key", api_key);
-                params.insert("api_secret", api_secret);
-                if customer_id.is_some() {
-                    params.insert("customer_id", customer_id.ok_or(ErrorKind::BadParse)?);
-                }
-                Ok(Box::new(BitstampApi::new(&params)?))
-            }
-
-            Exchange::Kraken => Ok(Box::new(KrakenApi::new(api_key, api_secret)?)),
-
-            Exchange::Poloniex => Ok(Box::new(PoloniexApi::new(api_key, api_secret)?)),
+            Exchange::Bitstamp => Ok(Box::new(BitstampApi::new(creds)?)),
+            Exchange::Kraken => Ok(Box::new(KrakenApi::new(creds)?)),
+            Exchange::Poloniex => Ok(Box::new(PoloniexApi::new(creds)?)),
         }
     }
 
@@ -45,13 +39,19 @@ impl Coinnect {
     /// For this example, you could use load your Bitstamp account with
     /// `new_from_file(Exchange::Bitstamp, "account_bitstamp", Path::new("/keys.json"))`
     pub fn new_from_file(exchange: Exchange,
-                         config_name: &str,
+                         name: &str,
                          path: PathBuf)
                          -> Result<Box<ExchangeApi>> {
         match exchange {
-            Exchange::Bitstamp => Ok(Box::new(BitstampApi::new_from_file(config_name, path)?)),
-            Exchange::Kraken => Ok(Box::new(KrakenApi::new_from_file(config_name, path)?)),
-            Exchange::Poloniex => Ok(Box::new(PoloniexApi::new_from_file(config_name, path)?)),
+            Exchange::Bitstamp => {
+                Ok(Box::new(BitstampApi::new(BitstampCreds::new_from_file(name, path)?)?))
+            }
+            Exchange::Kraken => {
+                Ok(Box::new(KrakenApi::new(KrakenCreds::new_from_file(name, path)?)?))
+            }
+            Exchange::Poloniex => {
+                Ok(Box::new(PoloniexApi::new(PoloniexCreds::new_from_file(name, path)?)?))
+            }
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -6,6 +6,7 @@
 use serde_json;
 use hyper;
 use data_encoding;
+use exchange::Exchange;
 
 error_chain!{
     types {
@@ -67,6 +68,11 @@ error_chain!{
                 display("Fail to parse field \"{}\".", field)
         }
 
+        InvalidFieldValue(field: String) {
+            description("InvalidFieldValue")
+                display("Invalid value for field \"{}\".", field)
+        }
+
         MissingField(field: String) {
             description("MissingFiled")
                 display("Missing field \"{}\".", field)
@@ -85,6 +91,16 @@ error_chain!{
         MissingPrice{
             description("MissingPrice")
                 display("No price specified.")
+        }
+
+        InvalidConfigType(expected: Exchange, find: Exchange){
+            description("InvalidConfigType")
+                display("Invalid config: \nExpected: {:?}\nFind: {:?}", expected, find)
+        }
+
+        InvalidExchange(value: String) {
+            description("InvalidExchange")
+                display("Invalid exchange: \"{}\"", value)
         }
     }
 }

--- a/src/exchange.rs
+++ b/src/exchange.rs
@@ -1,17 +1,44 @@
 //! This module contains Exchange enum.
 
 use std::fmt::Debug;
+use std::convert::Into;
+use std::str::FromStr;
 
 use error::*;
 use pair::Pair;
 use types::*;
 
-#[derive(Debug)]
-#[derive(PartialEq)]
+
+
+
+#[derive(Debug, PartialEq, Clone, Copy)]
 pub enum Exchange {
     Bitstamp,
     Kraken,
     Poloniex,
+}
+
+impl Into<String> for Exchange {
+    fn into(self) -> String {
+        match self {
+            Exchange::Bitstamp => "Bitstamp".to_string(),
+            Exchange::Kraken => "Kraken".to_string(),
+            Exchange::Poloniex => "Poloniex".to_string(),
+        }
+    }
+}
+
+impl FromStr for Exchange {
+    type Err = Error;
+
+    fn from_str(input: &str) -> ::std::result::Result<Self, Self::Err> {
+        match input.to_lowercase().as_str() {
+            "bitstamp" => Ok(Exchange::Bitstamp),
+            "kraken" => Ok(Exchange::Kraken),
+            "poloniex" => Ok(Exchange::Poloniex),
+            _ => Err(ErrorKind::InvalidExchange(input.to_string()).into()),
+        }
+    }
 }
 
 pub trait ExchangeApi: Debug {

--- a/src/helpers/mod.rs
+++ b/src/helpers/mod.rs
@@ -1,6 +1,9 @@
 
 #![warn(clone_double_ref)]
 
+use serde_json::Value;
+use error::*;
+
 use std::collections::HashMap;
 use time;
 
@@ -32,4 +35,12 @@ pub fn strip_empties(x: &mut HashMap<&str, &str>) {
     for empty in empties {
         x.remove(&empty);
     }
+}
+
+pub fn get_json_string<'a>(json_obj: &'a Value, key: &str) -> Result<&'a str> {
+    Ok(json_obj
+           .get(key)
+           .ok_or_else(|| ErrorKind::MissingField(key.to_string()))?
+           .as_str()
+           .ok_or_else(|| ErrorKind::InvalidFieldFormat(key.to_string()))?)
 }

--- a/src/helpers/mod.rs
+++ b/src/helpers/mod.rs
@@ -44,3 +44,11 @@ pub fn get_json_string<'a>(json_obj: &'a Value, key: &str) -> Result<&'a str> {
            .as_str()
            .ok_or_else(|| ErrorKind::InvalidFieldFormat(key.to_string()))?)
 }
+
+pub fn from_json_float(json_obj: &Value, key: &str) -> Result<f64> {
+    Ok(json_obj
+           .as_str()
+           .ok_or_else(|| ErrorKind::MissingField(key.to_string()))?
+           .parse::<f64>()
+           .chain_err(|| ErrorKind::InvalidFieldFormat(key.to_string()))?)
+}

--- a/src/kraken/credentials.rs
+++ b/src/kraken/credentials.rs
@@ -36,14 +36,14 @@ impl KrakenCreds {
 
 
         //if api_key.is_empty() {
-        //warning!("No API key set for the Bistamp client");
+        //warning!("No API key set for the Bitstamp client");
         //}
         creds
             .data
             .insert("api_key".to_string(), api_key.to_string());
 
         //if api_secret.is_empty() {
-        //warning!("No API secret set for the Bistamp client");
+        //warning!("No API secret set for the Bitstamp client");
         //}
         creds
             .data

--- a/src/kraken/credentials.rs
+++ b/src/kraken/credentials.rs
@@ -1,0 +1,134 @@
+//! Contains the Kraken credentials.
+
+use std::collections::HashMap;
+use std::str::FromStr;
+
+use serde_json;
+use serde_json::Value;
+
+use coinnect::Credentials;
+use exchange::Exchange;
+
+use std::fs::File;
+use std::io::Read;
+use std::path::PathBuf;
+use error::*;
+
+#[derive(Debug)]
+pub struct KrakenCreds {
+    exchange: Exchange,
+    name: String,
+    data: HashMap<String, String>,
+}
+
+impl KrakenCreds {
+    /// Create a new `KrakenCreds` from arguments.
+    pub fn new(name: &str, api_key: &str, api_secret: &str) -> Self {
+        let mut creds = KrakenCreds {
+            data: HashMap::new(),
+            exchange: Exchange::Kraken,
+            name: if name.is_empty() {
+                "KrakenClient".to_string()
+            } else {
+                name.to_string()
+            },
+        };
+
+
+        //if api_key.is_empty() {
+        //warning!("No API key set for the Bistamp client");
+        //}
+        creds
+            .data
+            .insert("api_key".to_string(), api_key.to_string());
+
+        //if api_secret.is_empty() {
+        //warning!("No API secret set for the Bistamp client");
+        //}
+        creds
+            .data
+            .insert("api_secret".to_string(), api_secret.to_string());
+
+        creds
+    }
+
+
+    /// Create a new `KrakenCreds` from a json configuration file. This file must follow this
+    /// structure:
+    ///
+    /// ```json
+    /// {
+    ///     "account_kraken": {
+    ///         "exchange"  : "kraken",
+    ///         "api_key"   : "123456789ABCDEF",
+    ///         "api_secret": "ABC&EF?abcdef"
+    ///     },
+    ///     "account_bitstamp": {
+    ///         "exchange"   : "bitstamp",
+    ///         "api_key"    : "1234567890ABCDEF1234567890ABCDEF",
+    ///         "api_secret" : "1234567890ABCDEF1234567890ABCDEF",
+    ///         "customer_id": "123456"
+    ///     }
+    /// }
+    /// ```
+    /// For this example, you could use load your Kraken account with
+    /// `KrakenAPI::new(KrakenCreds::new_from_file("account_kraken", Path::new("/keys.json")))`
+    pub fn new_from_file(name: &str, path: PathBuf) -> Result<Self> {
+        let mut f = File::open(&path)?;
+        let mut buffer = String::new();
+        f.read_to_string(&mut buffer)?;
+
+        let data: Value = serde_json::from_str(&buffer)?;
+        let json_obj = data.as_object()
+            .ok_or_else(|| ErrorKind::BadParse)?
+            .get(name)
+            .ok_or_else(|| ErrorKind::MissingField(name.to_string()))?;
+        let api_key = json_obj
+            .get("api_key")
+            .ok_or_else(|| ErrorKind::MissingField("api_key".to_string()))?
+            .as_str()
+            .ok_or_else(|| ErrorKind::InvalidFieldFormat("api_key".to_string()))?;
+        let api_secret =
+            json_obj
+                .get("api_secret")
+                .ok_or_else(|| ErrorKind::MissingField("api_secret".to_string()))?
+                .as_str()
+                .ok_or_else(|| ErrorKind::InvalidFieldFormat("api_secret".to_string()))?;
+        let exchange = {
+            let exchange_str =
+                json_obj
+                    .get("exchange")
+                    .ok_or_else(|| ErrorKind::MissingField("customer_id".to_string()))?
+                    .as_str()
+                    .ok_or_else(|| ErrorKind::InvalidFieldFormat("customer_id".to_string()))?;
+
+            Exchange::from_str(exchange_str)
+                .chain_err(|| ErrorKind::InvalidFieldValue("exchange".to_string()))?
+        };
+
+        if exchange != Exchange::Kraken {
+            return Err(ErrorKind::InvalidConfigType(Exchange::Kraken, exchange).into());
+        }
+
+        Ok(KrakenCreds::new(name, api_key, api_secret))
+    }
+}
+
+impl Credentials for KrakenCreds {
+    /// Return a value from the credentials.
+    fn get(&self, key: &str) -> Option<String> {
+        if let Some(res) = self.data.get(key) {
+            Some(res.clone())
+        } else {
+            None
+        }
+    }
+
+    fn name(&self) -> String {
+        self.name.clone()
+    }
+
+    fn exchange(&self) -> Exchange {
+        self.exchange
+    }
+}

--- a/src/kraken/credentials.rs
+++ b/src/kraken/credentials.rs
@@ -8,11 +8,12 @@ use serde_json::Value;
 
 use coinnect::Credentials;
 use exchange::Exchange;
+use helpers;
+use error::*;
 
 use std::fs::File;
 use std::io::Read;
 use std::path::PathBuf;
-use error::*;
 
 #[derive(Debug)]
 pub struct KrakenCreds {
@@ -83,25 +84,10 @@ impl KrakenCreds {
             .ok_or_else(|| ErrorKind::BadParse)?
             .get(name)
             .ok_or_else(|| ErrorKind::MissingField(name.to_string()))?;
-        let api_key = json_obj
-            .get("api_key")
-            .ok_or_else(|| ErrorKind::MissingField("api_key".to_string()))?
-            .as_str()
-            .ok_or_else(|| ErrorKind::InvalidFieldFormat("api_key".to_string()))?;
-        let api_secret =
-            json_obj
-                .get("api_secret")
-                .ok_or_else(|| ErrorKind::MissingField("api_secret".to_string()))?
-                .as_str()
-                .ok_or_else(|| ErrorKind::InvalidFieldFormat("api_secret".to_string()))?;
+        let api_key = helpers::get_json_string(json_obj, "api_key")?;
+        let api_secret = helpers::get_json_string(json_obj, "api_secret")?;
         let exchange = {
-            let exchange_str =
-                json_obj
-                    .get("exchange")
-                    .ok_or_else(|| ErrorKind::MissingField("customer_id".to_string()))?
-                    .as_str()
-                    .ok_or_else(|| ErrorKind::InvalidFieldFormat("customer_id".to_string()))?;
-
+            let exchange_str = helpers::get_json_string(json_obj, "exchange")?;
             Exchange::from_str(exchange_str)
                 .chain_err(|| ErrorKind::InvalidFieldValue("exchange".to_string()))?
         };

--- a/src/kraken/generic_api.rs
+++ b/src/kraken/generic_api.rs
@@ -22,26 +22,10 @@ impl ExchangeApi for KrakenApi {
 
         let result = utils::parse_result(&raw_response)?;
 
-        let price = result[*pair_name]["c"][0]
-            .as_str()
-            .ok_or_else(|| ErrorKind::MissingField(format!("{}.c", pair_name)))?
-            .parse::<f64>()
-            .chain_err(|| ErrorKind::InvalidFieldFormat(format!("{}.c", pair_name)))?;
-        let ask = result[*pair_name]["a"][0]
-            .as_str()
-            .ok_or_else(|| ErrorKind::MissingField(format!("{}.a", pair_name)))?
-            .parse::<f64>()
-            .chain_err(|| ErrorKind::InvalidFieldFormat(format!("{}.a", pair_name)))?;
-        let bid = result[*pair_name]["b"][0]
-            .as_str()
-            .ok_or_else(|| ErrorKind::MissingField(format!("{}.b", pair_name)))?
-            .parse::<f64>()
-            .chain_err(|| ErrorKind::InvalidFieldFormat(format!("{}.b", pair_name)))?;
-        let vol = result[*pair_name]["v"][1]
-            .as_str()
-            .ok_or_else(|| ErrorKind::MissingField(format!("{}.v", pair_name)))?
-            .parse::<f64>()
-            .chain_err(|| ErrorKind::InvalidFieldFormat(format!("{}.v", pair_name)))?;
+        let price = helpers::from_json_float(&result[*pair_name]["c"][0], "c")?;
+        let ask = helpers::from_json_float(&result[*pair_name]["a"][0], "a")?;
+        let bid = helpers::from_json_float(&result[*pair_name]["b"][0], "b")?;
+        let vol = helpers::from_json_float(&result[*pair_name]["v"][0], "v")?;
 
         Ok(Ticker {
                timestamp: helpers::get_unix_timestamp_ms(),

--- a/src/kraken/mod.rs
+++ b/src/kraken/mod.rs
@@ -3,4 +3,8 @@
 
 pub mod api;
 pub mod generic_api;
+pub mod credentials;
 pub mod utils;
+
+pub use self::credentials::KrakenCreds;
+pub use self::api::KrakenApi;

--- a/src/poloniex/credentials.rs
+++ b/src/poloniex/credentials.rs
@@ -8,11 +8,12 @@ use serde_json::Value;
 
 use coinnect::Credentials;
 use exchange::Exchange;
+use helpers;
+use error::*;
 
 use std::fs::File;
 use std::io::Read;
 use std::path::PathBuf;
-use error::*;
 
 #[derive(Debug)]
 pub struct PoloniexCreds {
@@ -83,25 +84,10 @@ impl PoloniexCreds {
             .ok_or_else(|| ErrorKind::BadParse)?
             .get(name)
             .ok_or_else(|| ErrorKind::MissingField(name.to_string()))?;
-        let api_key = json_obj
-            .get("api_key")
-            .ok_or_else(|| ErrorKind::MissingField("api_key".to_string()))?
-            .as_str()
-            .ok_or_else(|| ErrorKind::InvalidFieldFormat("api_key".to_string()))?;
-        let api_secret =
-            json_obj
-                .get("api_secret")
-                .ok_or_else(|| ErrorKind::MissingField("api_secret".to_string()))?
-                .as_str()
-                .ok_or_else(|| ErrorKind::InvalidFieldFormat("api_secret".to_string()))?;
+        let api_key = helpers::get_json_string(json_obj, "api_key")?;
+        let api_secret = helpers::get_json_string(json_obj, "api_secret")?;
         let exchange = {
-            let exchange_str =
-                json_obj
-                    .get("exchange")
-                    .ok_or_else(|| ErrorKind::MissingField("customer_id".to_string()))?
-                    .as_str()
-                    .ok_or_else(|| ErrorKind::InvalidFieldFormat("customer_id".to_string()))?;
-
+            let exchange_str = helpers::get_json_string(json_obj, "exchange")?;
             Exchange::from_str(exchange_str)
                 .chain_err(|| ErrorKind::InvalidFieldValue("exchange".to_string()))?
         };

--- a/src/poloniex/credentials.rs
+++ b/src/poloniex/credentials.rs
@@ -36,14 +36,14 @@ impl PoloniexCreds {
 
 
         //if api_key.is_empty() {
-        //warning!("No API key set for the Bistamp client");
+        //warning!("No API key set for the Bitstamp client");
         //}
         creds
             .data
             .insert("api_key".to_string(), api_key.to_string());
 
         //if api_secret.is_empty() {
-        //warning!("No API secret set for the Bistamp client");
+        //warning!("No API secret set for the Bitstamp client");
         //}
         creds
             .data
@@ -58,8 +58,8 @@ impl PoloniexCreds {
     ///
     /// ```json
     /// {
-    ///     "account_kraken": {
-    ///         "exchange"  : "kraken",
+    ///     "account_poloniex": {
+    ///         "exchange"  : "poloniex",
     ///         "api_key"   : "123456789ABCDEF",
     ///         "api_secret": "ABC&EF?abcdef"
     ///     },

--- a/src/poloniex/credentials.rs
+++ b/src/poloniex/credentials.rs
@@ -1,0 +1,134 @@
+//! Contains the Poloniex credentials.
+
+use std::collections::HashMap;
+use std::str::FromStr;
+
+use serde_json;
+use serde_json::Value;
+
+use coinnect::Credentials;
+use exchange::Exchange;
+
+use std::fs::File;
+use std::io::Read;
+use std::path::PathBuf;
+use error::*;
+
+#[derive(Debug)]
+pub struct PoloniexCreds {
+    exchange: Exchange,
+    name: String,
+    data: HashMap<String, String>,
+}
+
+impl PoloniexCreds {
+    /// Create a new `PoloniexCreds` from arguments.
+    pub fn new(name: &str, api_key: &str, api_secret: &str) -> Self {
+        let mut creds = PoloniexCreds {
+            data: HashMap::new(),
+            exchange: Exchange::Poloniex,
+            name: if name.is_empty() {
+                "PoloniexClient".to_string()
+            } else {
+                name.to_string()
+            },
+        };
+
+
+        //if api_key.is_empty() {
+        //warning!("No API key set for the Bistamp client");
+        //}
+        creds
+            .data
+            .insert("api_key".to_string(), api_key.to_string());
+
+        //if api_secret.is_empty() {
+        //warning!("No API secret set for the Bistamp client");
+        //}
+        creds
+            .data
+            .insert("api_secret".to_string(), api_secret.to_string());
+
+        creds
+    }
+
+
+    /// Create a new `PoloniexCreds` from a json configuration file. This file must follow this
+    /// structure:
+    ///
+    /// ```json
+    /// {
+    ///     "account_kraken": {
+    ///         "exchange"  : "kraken",
+    ///         "api_key"   : "123456789ABCDEF",
+    ///         "api_secret": "ABC&EF?abcdef"
+    ///     },
+    ///     "account_bitstamp": {
+    ///         "exchange"   : "bitstamp",
+    ///         "api_key"    : "1234567890ABCDEF1234567890ABCDEF",
+    ///         "api_secret" : "1234567890ABCDEF1234567890ABCDEF",
+    ///         "customer_id": "123456"
+    ///     }
+    /// }
+    /// ```
+    /// For this example, you could use load your Poloniex account with
+    /// `PoloniexAPI::new(PoloniexCreds::new_from_file("account_kraken", Path::new("/keys.json")))`
+    pub fn new_from_file(name: &str, path: PathBuf) -> Result<Self> {
+        let mut f = File::open(&path)?;
+        let mut buffer = String::new();
+        f.read_to_string(&mut buffer)?;
+
+        let data: Value = serde_json::from_str(&buffer)?;
+        let json_obj = data.as_object()
+            .ok_or_else(|| ErrorKind::BadParse)?
+            .get(name)
+            .ok_or_else(|| ErrorKind::MissingField(name.to_string()))?;
+        let api_key = json_obj
+            .get("api_key")
+            .ok_or_else(|| ErrorKind::MissingField("api_key".to_string()))?
+            .as_str()
+            .ok_or_else(|| ErrorKind::InvalidFieldFormat("api_key".to_string()))?;
+        let api_secret =
+            json_obj
+                .get("api_secret")
+                .ok_or_else(|| ErrorKind::MissingField("api_secret".to_string()))?
+                .as_str()
+                .ok_or_else(|| ErrorKind::InvalidFieldFormat("api_secret".to_string()))?;
+        let exchange = {
+            let exchange_str =
+                json_obj
+                    .get("exchange")
+                    .ok_or_else(|| ErrorKind::MissingField("customer_id".to_string()))?
+                    .as_str()
+                    .ok_or_else(|| ErrorKind::InvalidFieldFormat("customer_id".to_string()))?;
+
+            Exchange::from_str(exchange_str)
+                .chain_err(|| ErrorKind::InvalidFieldValue("exchange".to_string()))?
+        };
+
+        if exchange != Exchange::Poloniex {
+            return Err(ErrorKind::InvalidConfigType(Exchange::Poloniex, exchange).into());
+        }
+
+        Ok(PoloniexCreds::new(name, api_key, api_secret))
+    }
+}
+
+impl Credentials for PoloniexCreds {
+    /// Return a value from the credentials.
+    fn get(&self, key: &str) -> Option<String> {
+        if let Some(res) = self.data.get(key) {
+            Some(res.clone())
+        } else {
+            None
+        }
+    }
+
+    fn name(&self) -> String {
+        self.name.clone()
+    }
+
+    fn exchange(&self) -> Exchange {
+        self.exchange
+    }
+}

--- a/src/poloniex/generic_api.rs
+++ b/src/poloniex/generic_api.rs
@@ -21,30 +21,10 @@ impl ExchangeApi for PoloniexApi {
 
         let result = utils::parse_result(&raw_response)?;
 
-        let price =
-            result[*pair_name]["last"]
-                .as_str()
-                .ok_or_else(|| ErrorKind::MissingField(format!("{}.last", pair_name)))?
-                .parse::<f64>()
-                .chain_err(|| ErrorKind::InvalidFieldFormat(format!("{}.last", pair_name)))?;
-        let ask =
-            result[*pair_name]["lowestAsk"]
-                .as_str()
-                .ok_or_else(|| ErrorKind::MissingField(format!("{}.lowestAsk", pair_name)))?
-                .parse::<f64>()
-                .chain_err(|| ErrorKind::InvalidFieldFormat(format!("{}.lowestAsk", pair_name)))?;
-        let bid =
-            result[*pair_name]["highestBid"]
-                .as_str()
-                .ok_or_else(|| ErrorKind::MissingField(format!("{}.hightestBid", pair_name)))?
-                .parse::<f64>()
-                .chain_err(|| ErrorKind::InvalidFieldFormat(format!("{}.highestBid", pair_name)))?;
-        let vol =
-            result[*pair_name]["quoteVolume"]
-                .as_str()
-                .ok_or_else(|| ErrorKind::MissingField(format!("{}.quoteVolume", pair_name)))?
-                .parse::<f64>()
-                .chain_err(|| ErrorKind::InvalidFieldFormat(format!("{}.quoteVolume", pair_name)))?;
+        let price = helpers::from_json_float(&result[*pair_name]["last"], "last")?;
+        let ask = helpers::from_json_float(&result[*pair_name]["lowestAsk"], "lowestAsk")?;
+        let bid = helpers::from_json_float(&result[*pair_name]["highestBid"], "highestBid")?;
+        let vol = helpers::from_json_float(&result[*pair_name]["quoteVolume"], "quoteVolume")?;
 
         Ok(Ticker {
                timestamp: helpers::get_unix_timestamp_ms(),

--- a/src/poloniex/mod.rs
+++ b/src/poloniex/mod.rs
@@ -2,4 +2,8 @@
 
 pub mod api;
 pub mod generic_api;
+pub mod credentials;
 pub mod utils;
+
+pub use self::credentials::PoloniexCreds;
+pub use self::api::PoloniexApi;

--- a/tests/bitstamp.rs
+++ b/tests/bitstamp.rs
@@ -2,12 +2,11 @@
 mod bitstamp_tests {
     extern crate coinnect;
     use self::coinnect::bitstamp::utils;
-    use self::coinnect::bitstamp::api::BitstampApi;
+    use self::coinnect::bitstamp::{BitstampApi, BitstampCreds};
+    use self::coinnect::kraken::KrakenCreds;
 
     use self::coinnect::exchange::ExchangeApi;
     use self::coinnect::pair::Pair;
-
-    use std::collections::HashMap;
 
     #[test]
     fn build_url_should_return_the_a_url() {
@@ -21,83 +20,92 @@ mod bitstamp_tests {
     }
 
     #[test]
+    fn fail_with_invalid_creds() {
+        let creds = KrakenCreds::new("", "", "");
+        let res = BitstampApi::new(creds);
+        assert_eq!(res.unwrap_err().to_string(),
+                   "Invalid config: \nExpected: Bitstamp\nFind: Kraken");
+    }
+
+
+    #[test]
     fn can_get_real_bitstamp_tick() {
-        let params = HashMap::new();
-        let mut api = BitstampApi::new(&params).unwrap();
+        let creds = BitstampCreds::new("", "", "", "");
+        let mut api = BitstampApi::new(creds).unwrap();
         api.ticker(Pair::BTC_USD).unwrap();
     }
 
     #[test]
     fn ticker_should_have_the_correct_last() {
-        let params = HashMap::new();
-        let mut api = BitstampApi::new(&params).unwrap();
+        let creds = BitstampCreds::new("", "", "", "");
+        let mut api = BitstampApi::new(creds).unwrap();
         let result = api.ticker(Pair::BTC_USD);
         assert_ne!(result.unwrap().last_trade_price, 0.0);
     }
     #[test]
     fn ticker_should_have_the_correct_high() {
-        let params = HashMap::new();
-        let mut api = BitstampApi::new(&params).unwrap();
+        let creds = BitstampCreds::new("", "", "", "");
+        let mut api = BitstampApi::new(creds).unwrap();
         let result = api.ticker(Pair::BTC_USD);
         assert_ne!(result.unwrap().highest_bid, 0.0);
     }
     #[test]
     fn ticker_should_have_the_correct_low() {
-        let params = HashMap::new();
-        let mut api = BitstampApi::new(&params).unwrap();
+        let creds = BitstampCreds::new("", "", "", "");
+        let mut api = BitstampApi::new(creds).unwrap();
         let result = api.ticker(Pair::BTC_USD);
         assert_ne!(result.unwrap().lowest_ask, 0.0);
     }
     #[test]
     fn ticker_should_have_the_correct_volume() {
-        let params = HashMap::new();
-        let mut api = BitstampApi::new(&params).unwrap();
+        let creds = BitstampCreds::new("", "", "", "");
+        let mut api = BitstampApi::new(creds).unwrap();
         let result = api.ticker(Pair::BTC_USD);
         assert_ne!(result.unwrap().volume.unwrap(), 0.0);
     }
 
     #[test]
     fn should_return_an_order_book() {
-        let params = HashMap::new();
-        let mut api = BitstampApi::new(&params).unwrap();
+        let creds = BitstampCreds::new("", "", "", "");
+        let mut api = BitstampApi::new(creds).unwrap();
         let result = api.return_order_book(Pair::BTC_USD);
         assert_eq!(result.is_ok(), true);
     }
 
     #[test]
     fn order_book_should_have_a_timestamp() {
-        let params = HashMap::new();
-        let mut api = BitstampApi::new(&params).unwrap();
+        let creds = BitstampCreds::new("", "", "", "");
+        let mut api = BitstampApi::new(creds).unwrap();
         let result = api.return_order_book(Pair::BTC_USD);
         assert!(result.unwrap().contains_key("timestamp"));
     }
     #[test]
     fn order_book_should_have_bids() {
-        let params = HashMap::new();
-        let mut api = BitstampApi::new(&params).unwrap();
+        let creds = BitstampCreds::new("", "", "", "");
+        let mut api = BitstampApi::new(creds).unwrap();
         let result = api.return_order_book(Pair::BTC_USD);
         assert!(result.unwrap().contains_key("bids"));
     }
     #[test]
     fn order_book_should_have_asks() {
-        let params = HashMap::new();
-        let mut api = BitstampApi::new(&params).unwrap();
+        let creds = BitstampCreds::new("", "", "", "");
+        let mut api = BitstampApi::new(creds).unwrap();
         let result = api.return_order_book(Pair::BTC_USD);
         assert!(result.unwrap().contains_key("bids"));
     }
 
     #[test]
     fn order_book_should_have_asks_for_btcusd() {
-        let params = HashMap::new();
-        let mut api = BitstampApi::new(&params).unwrap();
+        let creds = BitstampCreds::new("", "", "", "");
+        let mut api = BitstampApi::new(creds).unwrap();
         assert!(api.return_order_book(Pair::BTC_USD)
                     .unwrap()
                     .contains_key("asks"));
     }
     #[test]
     fn order_book_should_have_asks_for_btceur() {
-        let params = HashMap::new();
-        let mut api = BitstampApi::new(&params).unwrap();
+        let creds = BitstampCreds::new("", "", "", "");
+        let mut api = BitstampApi::new(creds).unwrap();
         assert!(api.return_order_book(Pair::BTC_USD)
                     .unwrap()
                     .contains_key("asks"));
@@ -125,8 +133,8 @@ mod bitstamp_tests {
 
     #[test]
     fn should_return_the_trade_history_for_btc_usd() {
-        let params = HashMap::new();
-        let mut api = BitstampApi::new(&params).unwrap();
+        let creds = BitstampCreds::new("", "", "", "");
+        let mut api = BitstampApi::new(creds).unwrap();
         let result = api.return_trade_history(Pair::BTC_USD);
 
         assert_eq!(result.is_ok(), false);
@@ -138,7 +146,8 @@ mod bitstamp_tests {
     fn balance_should_have_usd_and_btc_balance() {
         use std::path::PathBuf;
         let path = PathBuf::from("./keys_real.json");
-        let mut api = BitstampApi::new_from_file("account_bitstamp", path).unwrap();
+        let creds = BitstampCreds::new_from_file("account_bitstamp", path).unwrap();
+        let mut api = BitstampApi::new(creds).unwrap();
         let result = api.return_balances().unwrap();
         let result_looking_for_usd = result.clone();
         let result_looking_for_btc = result.clone();

--- a/tests/coinnect.rs
+++ b/tests/coinnect.rs
@@ -5,19 +5,19 @@ mod coinnect_tests {
     use std::path::PathBuf;
 
     use self::coinnect::coinnect::Coinnect;
-    use self::coinnect::error::*;
     use self::coinnect::exchange::{Exchange, ExchangeApi};
     use self::coinnect::currency::Currency;
+    use self::coinnect::kraken::KrakenCreds;
+    use self::coinnect::bitstamp::BitstampCreds;
+    use self::coinnect::poloniex::PoloniexCreds;
+    use self::coinnect::error::*;
     use self::coinnect::pair::Pair;
     use self::coinnect::types::*;
 
     #[test]
     fn can_create_new_api_connection_to_bitstamp() {
-        let api: Box<ExchangeApi> = Coinnect::new(Exchange::Bitstamp,
-                                                  "bs_api_key",
-                                                  "bs_api_secret",
-                                                  Some("bs_cust_id"))
-                .unwrap();
+        let creds = BitstampCreds::new("test", "bs_api_key", "bs_api_secret", "bs_cust_id");
+        let api: Box<ExchangeApi> = Coinnect::new(Exchange::Bitstamp, creds).unwrap();
 
         assert_eq!(format!("{:?}", api),
                    "BitstampApi { last_request: 0, api_key: \"bs_api_key\", api_secret: \
@@ -38,11 +38,8 @@ mod coinnect_tests {
 
     #[test]
     fn coinnect_can_get_a_ticker_from_bitstamp() {
-        let mut api = Coinnect::new(Exchange::Bitstamp,
-                                    "bs_api_key",
-                                    "bs_api_secret",
-                                    Some("bs_cust_id"))
-                .unwrap();
+        let creds = BitstampCreds::new("test", "bs_api_key", "bs_api_secret", "bs_cust_id");
+        let mut api = Coinnect::new(Exchange::Bitstamp, creds).unwrap();
         let ticker = api.ticker(Pair::BTC_USD);
 
         assert_ne!(ticker.unwrap().last_trade_price, 0.0);
@@ -50,7 +47,8 @@ mod coinnect_tests {
 
     #[test]
     fn coinnect_can_get_a_ticker_from_kraken() {
-        let mut api = Coinnect::new(Exchange::Kraken, "api_key", "api_secret", None).unwrap();
+        let creds = KrakenCreds::new("test", "api_key", "api_secret");
+        let mut api = Coinnect::new(Exchange::Kraken, creds).unwrap();
         let ticker = api.ticker(Pair::BTC_EUR);
 
         assert_ne!(ticker.unwrap().last_trade_price, 0.0);
@@ -58,7 +56,8 @@ mod coinnect_tests {
 
     #[test]
     fn coinnect_can_get_a_ticker_from_poloniex() {
-        let mut api = Coinnect::new(Exchange::Poloniex, "api_key", "api_secret", None).unwrap();
+        let creds = PoloniexCreds::new("test", "api_key", "api_secret");
+        let mut api = Coinnect::new(Exchange::Poloniex, creds).unwrap();
         let ticker = api.ticker(Pair::ETH_BTC);
 
         assert_ne!(ticker.unwrap().last_trade_price, 0.0);
@@ -66,7 +65,8 @@ mod coinnect_tests {
 
     #[test]
     fn coinnect_can_get_an_orderbook_from_kraken() {
-        let mut api = Coinnect::new(Exchange::Kraken, "api_key", "api_secret", None).unwrap();
+        let creds = KrakenCreds::new("test", "api_key", "api_secret");
+        let mut api = Coinnect::new(Exchange::Kraken, creds).unwrap();
         let orderbook = api.orderbook(Pair::BTC_EUR);
 
         assert_ne!(orderbook.unwrap().avg_price().unwrap(), 0.0)
@@ -74,7 +74,8 @@ mod coinnect_tests {
 
     #[test]
     fn coinnect_can_get_an_orderbook_from_poloniex() {
-        let mut api = Coinnect::new(Exchange::Poloniex, "api_key", "api_secret", None).unwrap();
+        let creds = PoloniexCreds::new("test", "api_key", "api_secret");
+        let mut api = Coinnect::new(Exchange::Poloniex, creds).unwrap();
         let orderbook = api.orderbook(Pair::ETH_BTC);
 
         assert_ne!(orderbook.unwrap().avg_price().unwrap(), 0.0)
@@ -134,7 +135,8 @@ mod coinnect_tests {
     #[cfg_attr(not(feature = "kraken_private_tests"), ignore)]
     fn coinnect_can_add_order_from_kraken() {
         let path = PathBuf::from("./keys_real.json");
-        let mut api = Coinnect::new_from_file(Exchange::Kraken, "account_kraken", path).unwrap();
+        let creds = KrakenCreds::new_from_file("account_kraken", path).unwrap();
+        let mut api = Coinnect::new(Exchange::Kraken, creds).unwrap();
         // following request should return an error since Kraken minimum order size is 0.01
         let orderinfo = api.add_order(OrderType::BuyLimit, Pair::BTC_EUR, 0.00001, Some(1000.58));
 
@@ -146,8 +148,8 @@ mod coinnect_tests {
     #[cfg_attr(not(feature = "poloniex_private_tests"), ignore)]
     fn coinnect_can_add_order_from_poloniex() {
         let path = PathBuf::from("./keys_real.json");
-        let mut api = Coinnect::new_from_file(Exchange::Poloniex, "account_poloniex", path)
-            .unwrap();
+        let creds = PoloniexCreds::new_from_file("account_poloniex", path).unwrap();
+        let mut api = Coinnect::new(Exchange::Poloniex, creds).unwrap();
         // following request should return an error
         let orderinfo = api.add_order(OrderType::BuyLimit, Pair::ETH_BTC, 0.00001, Some(1000.58));
 
@@ -159,8 +161,8 @@ mod coinnect_tests {
     #[cfg_attr(not(feature = "bitstamp_private_tests"), ignore)]
     fn coinnect_can_add_order_from_bitstamp() {
         let path = PathBuf::from("./keys_real.json");
-        let mut api = Coinnect::new_from_file(Exchange::Bitstamp, "account_bitstamp", path)
-            .unwrap();
+        let creds = BitstampCreds::new_from_file("account_bitstamp", path).unwrap();
+        let mut api = Coinnect::new(Exchange::Bitstamp, creds).unwrap();
         // following request should return an error
         let orderinfo = api.add_order(OrderType::BuyLimit, Pair::EUR_USD, 0.00001, Some(1000.58));
 

--- a/tests/kraken.rs
+++ b/tests/kraken.rs
@@ -2,7 +2,16 @@
 mod kraken_tests {
     extern crate coinnect;
 
-    use self::coinnect::kraken::api::KrakenApi;
+    use self::coinnect::kraken::{KrakenApi, KrakenCreds};
+    use self::coinnect::bitstamp::BitstampCreds;
+
+    #[test]
+    fn fail_with_invalid_creds() {
+        let creds = BitstampCreds::new("", "", "", "");
+        let res = KrakenApi::new(creds);
+        assert_eq!(res.unwrap_err().to_string(),
+                   "Invalid config: \nExpected: Kraken\nFind: Bitstamp");
+    }
 
     /// IMPORTANT: Real keys are needed in order to retrieve the balance
     #[test]
@@ -10,7 +19,9 @@ mod kraken_tests {
     fn balance_should_return_a_result() {
         use std::path::PathBuf;
         let path = PathBuf::from("./keys_real.json");
-        let mut api = KrakenApi::new_from_file("account_kraken", path).unwrap();
+        let creds = KrakenCreds::new_from_file("account_kraken", path).unwrap();
+        let mut api = KrakenApi::new(creds).unwrap();
+
         let result = api.get_account_balance();
 
         assert!(result.unwrap().contains_key("result"));

--- a/tests/poloniex.rs
+++ b/tests/poloniex.rs
@@ -2,7 +2,16 @@
 mod poloniex_tests {
     extern crate coinnect;
 
-    use self::coinnect::poloniex::api::PoloniexApi;
+    use self::coinnect::poloniex::{PoloniexApi, PoloniexCreds};
+    use self::coinnect::bitstamp::BitstampCreds;
+
+    #[test]
+    fn fail_with_invalid_creds() {
+        let creds = BitstampCreds::new("", "", "", "");
+        let res = PoloniexApi::new(creds);
+        assert_eq!(res.unwrap_err().to_string(),
+                   "Invalid config: \nExpected: Poloniex\nFind: Bitstamp");
+    }
 
     /// IMPORTANT: Real keys are needed in order to retrieve the balance
     #[test]
@@ -10,7 +19,8 @@ mod poloniex_tests {
     fn balance_has_btc_key() {
         use std::path::PathBuf;
         let path = PathBuf::from("./keys_real.json");
-        let mut api = PoloniexApi::new_from_file("account_poloniex", path).unwrap();
+        let creds = PoloniexCreds::new_from_file("account_poloniex", path).unwrap();
+        let mut api = PoloniexApi::new(creds).unwrap();
         let result = api.return_balances();
 
         assert!(result.unwrap().contains_key("BTC"));


### PR DESCRIPTION
Fix #20 

The main change is in the call of any `new` method. Instead of giving credentials as arguments, it get a `Credential` trait object. Each `Credential` handle the parsing for any input from the user or the config file.

Before:
```rust
let mut my_api = Coinnect::new(Kraken, "api_key", "api_secret", None).unwrap();
```
Now:
```rust
let my_creds = KrakenCreds::new("my_optionnal_name", "api_key", "api_secret");
let mut my_api = Coinnect::new(Kraken, my_creds).unwrap();
```
