### PR TITLE
Improve Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ matrix:
       - nightly
 
 before_script:
-  - export PATH="$PATH:$HOME/.cargo/bin"
   - if [ ${TRAVIS_RUST_VERSION} = "nightly" ]; then
       cargo install rustfmt --force &&
       cargo install clippy --force;

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,6 @@ before_script:
 
 script:
   - cargo fmt -- --write-mode=diff
-  - cargo build
-  - cargo test
+  - cargo build --verbose
+  - cargo test --verbose
   - rustup run nightly cargo clippy

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,7 @@ rust:
 
 matrix:
   allow_failures:
-    - rust:
-      - nightly
+    - rust: nightly
 
 before_script:
   - if [ ${TRAVIS_RUST_VERSION} = "nightly" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: rust
 rust:
+  - 1.17.0 # oldest version supported
   - stable
   - nightly
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: rust
+cache: cargo
+sudo: false
 rust:
   - 1.17.0 # oldest version supported
   - stable
@@ -9,7 +11,6 @@ matrix:
     - rust:
       - nightly
 
-  cache: cargo
   before_script:
     - export PATH="$PATH:$HOME/.cargo/bin"
     - which rustfmt || cargo install rustfmt

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,14 +11,14 @@ matrix:
     - rust:
       - nightly
 
-  before_script:
-    - export PATH="$PATH:$HOME/.cargo/bin"
-    - which rustfmt || cargo install rustfmt
-    - which cargo-audit || cargo install cargo-audit
-    - which cargo-clippy || rustup install nigthly && rustup run nightly  cargo install clippy --force
+before_script:
+  - export PATH="$PATH:$HOME/.cargo/bin"
+  - which rustfmt || cargo install rustfmt
+  - which cargo-audit || cargo install cargo-audit
+  - which cargo-clippy || rustup install nigthly && rustup run nightly  cargo install clippy --force
 
-  script:
-    - cargo fmt -- --write-mode=diff
-    - cargo build
-    - cargo test
-    - rustup run nightly cargo clippy
+script:
+  - cargo fmt -- --write-mode=diff
+  - cargo build
+  - cargo test
+  - rustup run nightly cargo clippy

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,12 +13,16 @@ matrix:
 
 before_script:
   - export PATH="$PATH:$HOME/.cargo/bin"
-  - which rustfmt || cargo install rustfmt
   - which cargo-audit || cargo install cargo-audit
-  - which cargo-clippy || rustup install nigthly && rustup run nightly  cargo install clippy --force
+  - if [ ${TRAVIS_RUST_VERSION} = "nightly" ]; then
+      cargo install rustfmt --force &&
+      cargo install clippy --force;
+    fi
 
 script:
-  - cargo fmt -- --write-mode=diff
+  - if [ ${TRAVIS_RUST_VERSION} = "nightly" ]; then
+      cargo fmt -- --write-mode=diff &&
+      cargo clippy;
+    fi
   - cargo build --verbose
   - cargo test --verbose
-  - rustup run nightly cargo clippy

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ matrix:
 
 before_script:
   - export PATH="$PATH:$HOME/.cargo/bin"
-  - which cargo-audit || cargo install cargo-audit
   - if [ ${TRAVIS_RUST_VERSION} = "nightly" ]; then
       cargo install rustfmt --force &&
       cargo install clippy --force;


### PR DESCRIPTION
Run the actual commands specified in the Travis CI config. Tried to reduce some of the run-time redundancy and make the tests a bit more explicit by testing against the minimum supported version.