### PR TITLE
Replace Time with Chrono

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "coinnect"
 version = "0.5.1"
 license = "MIT"
-authors = ["Hugues Gaillard <hugues.gaillard@me.com>", "Alejandro Inestal"]
+authors = ["Hugues Gaillard <hugues.gaillard@me.com>", "Alejandro Inestal <ainestal@gmail.com>"]
 description = """
 A Rust library to connect to various crypto-currencies exchanges.
 """
@@ -33,7 +33,6 @@ path = "examples/generic_api.rs"
 [dependencies]
 hyper = "0.10.9"
 serde_json = "1.0.0"
-time = "0.1.37"
 hyper-native-tls = "0.2.2"
 lazy_static = "0.2"
 bidir-map = "0.3.2"
@@ -42,3 +41,4 @@ error-chain = "0.7.1"
 sha2 = "0.6.0"
 hmac = "0.3"
 bigdecimal = "0.0.10"
+chrono = "0.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coinnect"
-version = "0.5.1"
+version = "0.5.2"
 license = "MIT"
 authors = ["Hugues Gaillard <hugues.gaillard@me.com>", "Alejandro Inestal <ainestal@gmail.com>"]
 description = """

--- a/src/helpers/mod.rs
+++ b/src/helpers/mod.rs
@@ -7,7 +7,7 @@ use bigdecimal::BigDecimal;
 use std::str::FromStr;
 
 use std::collections::HashMap;
-use time;
+use chrono::prelude::*;
 
 // Helper functions
 
@@ -24,9 +24,10 @@ pub fn url_encode_hashmap(hashmap: &HashMap<&str, &str>) -> String {
 }
 
 pub fn get_unix_timestamp_ms() -> i64 {
-    let current_time = time::get_time();
-    //Calculate milliseconds
-    (current_time.sec as i64 * 1000) + (current_time.nsec as i64 / 1000 / 1000)
+    let now = Utc::now();
+    let seconds: i64 = now.timestamp();
+    let nanoseconds: i64 = now.nanosecond() as i64;
+    (seconds * 1000) + (nanoseconds / 1000 / 1000)
 }
 
 pub fn strip_empties(x: &mut HashMap<&str, &str>) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@ extern crate sha2;
 extern crate hmac;
 extern crate hyper_native_tls;
 extern crate serde_json;
-extern crate time;
+extern crate chrono;
 #[macro_use]
 extern crate lazy_static;
 extern crate bidir_map;


### PR DESCRIPTION
The Time library is deprecated. This PR replaces Time with Chrono.
The precision of the time used is now micro seconds instead of miliseconds