### PR TITLE
Burst

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "coinnect"
 version = "0.5.1"
 license = "MIT"
-authors = ["Hugues Gaillard <hugues.gaillard@me.com>", "Alejandro Inestal"]
+authors = ["Hugues Gaillard <hugues.gaillard@me.com>", "Alejandro Inestal <ainestal@gmail.com>"]
 description = """
 A Rust library to connect to various crypto-currencies exchanges.
 """
@@ -33,7 +33,6 @@ path = "examples/generic_api.rs"
 [dependencies]
 hyper = "0.10.9"
 serde_json = "1.0.0"
-time = "0.1.37"
 hyper-native-tls = "0.2.2"
 lazy_static = "0.2"
 bidir-map = "0.3.2"
@@ -42,3 +41,4 @@ error-chain = "0.7.1"
 sha2 = "0.6.0"
 hmac = "0.3"
 bigdecimal = "0.0.10"
+chrono = "0.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coinnect"
-version = "0.5.1"
+version = "0.5.2"
 license = "MIT"
 authors = ["Hugues Gaillard <hugues.gaillard@me.com>", "Alejandro Inestal <ainestal@gmail.com>"]
 description = """

--- a/src/bitstamp/api.rs
+++ b/src/bitstamp/api.rs
@@ -76,6 +76,11 @@ impl BitstampApi {
            })
     }
 
+    /// The number of calls in a given period is limited. In order to avoid a ban we limit
+    /// by default the number of api requests.
+    /// This function sets or removes the limitation.
+    /// Burst false implies no block.
+    /// Burst true implies there is a control over the number of calls allowed to the exchange
     pub fn set_burst(&mut self, burst: bool) {
         self.burst = burst
     }

--- a/src/bitstamp/utils.rs
+++ b/src/bitstamp/utils.rs
@@ -7,9 +7,6 @@ use serde_json;
 use serde_json::Value;
 use serde_json::value::Map;
 
-use std::thread;
-use std::time::Duration;
-
 use error::*;
 use helpers;
 use types::Currency;
@@ -39,15 +36,6 @@ pub fn get_pair_string(pair: &Pair) -> Option<&&str> {
 /// If the Pair is not supported, None is returned.
 pub fn get_pair_enum(pair: &str) -> Option<&Pair> {
     PAIRS_STRING.get_by_second(&pair)
-}
-
-pub fn block_or_continue(last_request: i64) {
-    let threshold: u64 = 1000; // 600 requests per 10 mins = 1 request per second
-    let offset: u64 = helpers::get_unix_timestamp_ms() as u64 - last_request as u64;
-    if offset < threshold {
-        let wait_ms = Duration::from_millis(threshold - offset);
-        thread::sleep(wait_ms);
-    }
 }
 
 pub fn build_signature(nonce: &str,
@@ -158,18 +146,5 @@ pub fn get_currency_string(currency: Currency) -> Option<String> {
         Currency::EUR => Some("EUR".to_string()),
         Currency::XRP => Some("XRP".to_string()),
         _ => None,
-    }
-}
-
-#[cfg(test)]
-mod utils_tests {
-    use super::*;
-
-    #[test]
-    fn should_block_when_enabled() {
-        let start = helpers::get_unix_timestamp_ms();
-        block_or_continue(start);
-        let end = helpers::get_unix_timestamp_ms();
-        assert!(end - start >= 1000)
     }
 }

--- a/src/bitstamp/utils.rs
+++ b/src/bitstamp/utils.rs
@@ -42,11 +42,11 @@ pub fn get_pair_enum(pair: &str) -> Option<&Pair> {
 }
 
 pub fn block_or_continue(last_request: i64) {
-    let threshold = 1000; // 600 requests per 10 mins = 1 request per second
-    let delay = helpers::get_unix_timestamp_ms() - last_request;
-    if delay < threshold {
-        let duration_ms = Duration::from_millis(delay as u64);
-        thread::sleep(duration_ms);
+    let threshold: u64 = 1000; // 600 requests per 10 mins = 1 request per second
+    let offset: u64 = helpers::get_unix_timestamp_ms() as u64 - last_request as u64;
+    if offset < threshold {
+        let wait_ms = Duration::from_millis(threshold - offset);
+        thread::sleep(wait_ms);
     }
 }
 
@@ -158,5 +158,18 @@ pub fn get_currency_string(currency: Currency) -> Option<String> {
         Currency::EUR => Some("EUR".to_string()),
         Currency::XRP => Some("XRP".to_string()),
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod utils_tests {
+    use super::*;
+
+    #[test]
+    fn should_block_when_enabled() {
+        let start = helpers::get_unix_timestamp_ms();
+        block_or_continue(start);
+        let end = helpers::get_unix_timestamp_ms();
+        assert!(end - start >= 1000)
     }
 }

--- a/src/helpers/mod.rs
+++ b/src/helpers/mod.rs
@@ -7,7 +7,7 @@ use bigdecimal::BigDecimal;
 use std::str::FromStr;
 
 use std::collections::HashMap;
-use time;
+use chrono::prelude::*;
 
 // Helper functions
 
@@ -24,9 +24,10 @@ pub fn url_encode_hashmap(hashmap: &HashMap<&str, &str>) -> String {
 }
 
 pub fn get_unix_timestamp_ms() -> i64 {
-    let current_time = time::get_time();
-    //Calculate milliseconds
-    (current_time.sec as i64 * 1000) + (current_time.nsec as i64 / 1000 / 1000)
+    let now = Utc::now();
+    let seconds: i64 = now.timestamp();
+    let nanoseconds: i64 = now.nanosecond() as i64;
+    (seconds * 1000) + (nanoseconds / 1000 / 1000)
 }
 
 pub fn strip_empties(x: &mut HashMap<&str, &str>) {

--- a/src/kraken/api.rs
+++ b/src/kraken/api.rs
@@ -78,12 +78,12 @@ impl KrakenApi {
         self.otp = Some(otp);
     }
 
-    fn block_or_continue(&self) {
-        let threshold = 2000; // 1 request/2sec
-        let delay = helpers::get_unix_timestamp_ms() - self.last_request;
-        if delay < threshold {
-            let duration_ms = Duration::from_millis(delay as u64);
-            thread::sleep(duration_ms);
+    pub fn block_or_continue(&self) {
+        let threshold: u64 = 2000; // 1 request/2sec
+        let offset: u64 = helpers::get_unix_timestamp_ms() as u64 - self.last_request as u64;
+        if offset < threshold {
+            let wait_ms = Duration::from_millis(threshold - offset);
+            thread::sleep(wait_ms);
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@ extern crate sha2;
 extern crate hmac;
 extern crate hyper_native_tls;
 extern crate serde_json;
-extern crate time;
+extern crate chrono;
 #[macro_use]
 extern crate lazy_static;
 extern crate bidir_map;

--- a/src/poloniex/api.rs
+++ b/src/poloniex/api.rs
@@ -73,11 +73,11 @@ impl PoloniexApi {
     }
 
     fn block_or_continue(&self) {
-        let threshold = 167; // 6 requests/sec = 1/6*1000
-        let delay = helpers::get_unix_timestamp_ms() - self.last_request;
-        if delay < threshold {
-            let duration_ms = Duration::from_millis(delay as u64);
-            thread::sleep(duration_ms);
+        let threshold: u64 = 167; // 6 requests/sec = 1/6*1000
+        let offset: u64 = helpers::get_unix_timestamp_ms() as u64 - self.last_request as u64;
+        if offset < threshold {
+            let wait_ms = Duration::from_millis(threshold - offset);
+            thread::sleep(wait_ms);
         }
     }
 

--- a/tests/coinnect.rs
+++ b/tests/coinnect.rs
@@ -24,7 +24,7 @@ mod coinnect_tests {
                    "BitstampApi { last_request: 0, api_key: \"bs_api_key\", api_secret: \
         \"bs_api_secret\", customer_id: \"bs_cust_id\", http_client: Client { \
                     redirect_policy: FollowAll, read_timeout: None, write_timeout: None, proxy: \
-                    None } }");
+                    None }, burst: false }");
     }
     #[test]
     fn can_create_new_api_connection_to_kraken() {


### PR DESCRIPTION
Enable Burst for the 3 exchanges

`set_burst` bypasses the `block_or_continue` to avoid waiting for requests.