### PR TITLE
Update `hyper-native-tls` from 0.2.2 to 0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ path = "examples/generic_api.rs"
 [dependencies]
 hyper = "0.10.10"
 serde_json = "1.0.0"
-hyper-native-tls = "0.2.2"
+hyper-native-tls = "0.3"
 lazy_static = "0.2"
 bidir-map = "1.0.0"
 data-encoding = "2.0.0-rc.1"


### PR DESCRIPTION
This fixes an issue where the `openssl` crate would not compile on
systems with more recent versions of OpenSSL. You can see a related
issue upstream [here](https://github.com/sfackler/rust-openssl/issues/987).